### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -4,11 +4,15 @@
     <meta charset="UTF-8">
     <title>Extension Options</title>
     <style>
-        body { 
-            font-family: Arial, sans-serif; 
-            margin: 20px; 
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
             background-color: #f0f0f0;
             color: #333333;
+        }
+        body.dark-mode {
+            background-color: #2b2b2b;
+            color: #e0e0e0;
         }
         h2 {
             color: #333333;
@@ -17,8 +21,8 @@
             display: block; 
             margin-bottom: 10px; 
         }
-        button { 
-            margin-top: 15px; 
+        button {
+            margin-top: 15px;
             padding: 6px 12px;
             background-color: #e0e0e0;
             color: #333333;
@@ -29,13 +33,21 @@
         button:hover {
             background-color: #d0d0d0;
         }
+        body.dark-mode button {
+            background-color: #444444;
+            color: #e0e0e0;
+            border-color: #666666;
+        }
+        body.dark-mode button:hover {
+            background-color: #555555;
+        }
         #status {
             font-weight: bold;
             color: #4caf50;
         }
     </style>
 </head>
-<body style="background-color: #f0f0f0; color: #333333;">
+<body>
     <h2>Extension Options</h2>
     <form id="options-form">
         <label>
@@ -53,6 +65,10 @@
         <label>
             <input type="checkbox" id="displayPostCount">
             Display post count on mod page
+        </label>
+        <label>
+            <input type="checkbox" id="darkMode">
+            Enable Dark Mode
         </label>
         <button type="submit">Save</button>
     </form>

--- a/src/optionsUtil.js
+++ b/src/optionsUtil.js
@@ -5,12 +5,18 @@
     const hoverChangelogs = document.getElementById('hoverChangelogs').checked;
     const infiniteScroll = document.getElementById('infiniteScroll').checked;
     const displayPostCount = document.getElementById('displayPostCount').checked;
-    chrome.storage.sync.set({
+    const data = {
       hideDownloadedMods,
       hoverChangelogs,
       infiniteScroll,
       displayPostCount
-    }, function() {
+    };
+    const darkModeEl = document.getElementById('darkMode');
+    if (darkModeEl) {
+      data.darkMode = darkModeEl.checked;
+    }
+    chrome.storage.sync.set(data, function() {
+      if (darkModeEl) applyDarkMode(darkModeEl.checked);
       const status = document.getElementById('status');
       if (status) {
         status.textContent = 'Options saved.';
@@ -24,14 +30,26 @@
       hideDownloadedMods: true,
       hoverChangelogs: true,
       infiniteScroll: true,
-      displayPostCount: true
+      displayPostCount: true,
+      darkMode: false
     }, function(items) {
       document.getElementById('hideDownloadedMods').checked = (typeof items.hideDownloadedMods === 'boolean') ? items.hideDownloadedMods : true;
       document.getElementById('hoverChangelogs').checked = (typeof items.hoverChangelogs === 'boolean') ? items.hoverChangelogs : true;
       document.getElementById('infiniteScroll').checked = (typeof items.infiniteScroll === 'boolean') ? items.infiniteScroll : true;
       document.getElementById('displayPostCount').checked = (typeof items.displayPostCount === 'boolean') ? items.displayPostCount : true;
+      const darkModeEl = document.getElementById('darkMode');
+      if (darkModeEl) {
+        darkModeEl.checked = (typeof items.darkMode === 'boolean') ? items.darkMode : false;
+      }
+      applyDarkMode(items.darkMode);
     });
   }
 
-  window.optionsUtil = { saveOptions, restoreOptions };
+  function applyDarkMode(enabled) {
+    if (typeof document !== 'undefined' && document.body) {
+      document.body.classList.toggle('dark-mode', !!enabled);
+    }
+  }
+
+  window.optionsUtil = { saveOptions, restoreOptions, applyDarkMode };
 })(window);

--- a/src/popup.html
+++ b/src/popup.html
@@ -4,13 +4,17 @@
     <meta charset="UTF-8">
     <title>Extension Options</title>
     <style>
-        body { 
-            font-family: Arial, sans-serif; 
-            margin: 10px; 
-            min-width: 250px; 
+        body {
+            font-family: Arial, sans-serif;
+            margin: 10px;
+            min-width: 250px;
             width: 100%;
             background-color: #f0f0f0;
             color: #333333;
+        }
+        body.dark-mode {
+            background-color: #2b2b2b;
+            color: #e0e0e0;
         }
         h3 {
             color: #333333;
@@ -19,8 +23,8 @@
             display: block; 
             margin-bottom: 10px; 
         }
-        button { 
-            margin-top: 15px; 
+        button {
+            margin-top: 15px;
             padding: 6px 12px;
             background-color: #e0e0e0;
             color: #333333;
@@ -31,6 +35,14 @@
         button:hover {
             background-color: #d0d0d0;
         }
+        body.dark-mode button {
+            background-color: #444444;
+            color: #e0e0e0;
+            border-color: #666666;
+        }
+        body.dark-mode button:hover {
+            background-color: #555555;
+        }
         #options-form {
             width: 100%;
         }
@@ -40,7 +52,7 @@
         }
     </style>
 </head>
-<body style="background-color: #f0f0f0; color: #333333;">
+<body>
     <h3>Better Nexusmods Options</h3>
     <form id="options-form">
         <label>


### PR DESCRIPTION
## Summary
- add dark mode preference to options util
- style popup and options pages for dark mode
- add checkbox in options page to toggle dark mode

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8eabd5dc8325b087885ec7db0900