### PR TITLE
Fix option persistence & infinite scroll error

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,31 +1,25 @@
-const POSTS_CACHE_PREFIX = 'nmdh_posts_';
 const POSTS_CACHE_EXPIRY_MS = 24 * 60 * 60 * 1000; // 1 day
 
-function getCacheKey(url) {
-  return POSTS_CACHE_PREFIX + btoa(url).replace(/[^a-z0-9]/gi, '');
-}
+// Simple in-memory cache to avoid hitting chrome.storage write limits
+const postsCache = {};
 
 chrome.runtime.onMessage.addListener((msg, sender, respond) => {
   if (msg.type === 'fetchPostCount' && msg.url) {
-    handlePostCount(msg.url).then(data => respond({ data }))
+    handlePostCount(msg.url)
+      .then(data => respond({ data }))
       .catch(err => respond({ error: err.toString() }));
     return true; // indicates async response
   }
 });
 
 async function handlePostCount(url) {
-  const key = getCacheKey(url);
-  const stored = await chrome.storage.local.get(key);
-  if (stored[key]) {
-    try {
-      const item = JSON.parse(stored[key]);
-      if (Date.now() < item.expiry) {
-        return item.data;
-      }
-    } catch (e) {}
+  const cached = postsCache[url];
+  if (cached && Date.now() < cached.expiry) {
+    return cached.data;
   }
+
   const data = await fetchPostCount(url);
-  await chrome.storage.local.set({ [key]: JSON.stringify({ data, expiry: Date.now() + POSTS_CACHE_EXPIRY_MS }) });
+  postsCache[url] = { data, expiry: Date.now() + POSTS_CACHE_EXPIRY_MS };
   return data;
 }
 

--- a/src/infiniteScroll.js
+++ b/src/infiniteScroll.js
@@ -1,6 +1,7 @@
 // Infinite Scroll for Nexus Mods main mods page
 let isInfiniteScrollEnabled = true; // Default to true, will be updated from storage
 let observer = null;
+let sentinel = null; // element used as the scroll sentinel
 
 (function() {
     console.log('[Betternexusmods] infiniteScroll.js loaded', window.location.href);

--- a/src/modComponentTweaks.js
+++ b/src/modComponentTweaks.js
@@ -221,22 +221,25 @@ function setupModComponentObserver() {
 function initModComponentTweaks() {
   // Get the displayPostCount option from storage
   chrome.storage.sync.get({ displayPostCount: true }, function(items) {
+    // Clean up any previous observers/elements when disabled
+    if (!items.displayPostCount) {
+      removePostCountElements();
+      return;
+    }
+
     // Only proceed if displayPostCount is enabled
-    if (items.displayPostCount) {
-      // Check if we're on a page with mod components
-      if (document.querySelector('[data-e2eid="mod-tile"]')) {
-        setupModComponentObserver();
-      } else {
-        // If no mod tiles yet, wait for them to appear
-        const observer = new MutationObserver((mutations, obs) => {
-          if (document.querySelector('[data-e2eid="mod-tile"]')) {
-            setupModComponentObserver();
-            obs.disconnect(); // Stop observing once we've found mod tiles
-          }
-        });
-        
-        observer.observe(document.body, { childList: true, subtree: true });
-      }
+    if (document.querySelector('[data-e2eid="mod-tile"]')) {
+      setupModComponentObserver();
+    } else {
+      // If no mod tiles yet, wait for them to appear
+      const observer = new MutationObserver((mutations, obs) => {
+        if (document.querySelector('[data-e2eid="mod-tile"]')) {
+          setupModComponentObserver();
+          obs.disconnect(); // Stop observing once we've found mod tiles
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
     }
   });
 }


### PR DESCRIPTION
## Summary
- use a simple in-memory cache in the background script to avoid hitting the Chrome storage write limit
- define `sentinel` in the infinite scroll script
- clean up post-count observers when the feature is disabled to prevent stale observers during tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683faf3bcb108325ae41580e8577735b