### PR TITLE
Limit post requests per page

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,7 +25,7 @@
       "js": [
         "index.js",
         "infiniteScroll.js",
-        "modComponentTweaks.js"
+        "posts.js"
       ],
       "css": [
         "styles.css"

--- a/src/posts.js
+++ b/src/posts.js
@@ -1,4 +1,6 @@
 let modTileObserver = null;
+const MAX_POST_FETCHES = 20;
+let postsFetched = 0;
 
 // === Mod Component Tweaks ===================================================
 // This file contains tweaks to enhance the mod component display
@@ -7,15 +9,21 @@ let modTileObserver = null;
  * Adds the number of posts to the mod component footer
  * Matches the style of other elements (endorsements, downloads, size)
  */
-function addPostsCountToModComponent() {
+async function addPostsCountToModComponent() {
   if ((typeof global !== 'undefined' && global.isTestEnvironment)) {
     console.log('MOD_TWEAKS_DEBUG: addPostsCountToModComponent called');
   }
   
   // Find all mod tiles on the page
   const modTiles = document.querySelectorAll('[data-e2eid="mod-tile"]');
-  
-  modTiles.forEach(async (modTile) => {
+
+  for (const modTile of modTiles) {
+    if (postsFetched >= MAX_POST_FETCHES) {
+      break;
+    }
+    if (modTile.getAttribute('data-posts-added') === 'true') {
+      continue;
+    }
     // Initial 'data-posts-added' check and setAttribute have been moved and integrated later in the logic:
     // 1. A check for an existing posts element is done after fetching postsCount.
     // 2. 'data-posts-added' attribute is set only after successful DOM insertion of the new postsElement.
@@ -41,6 +49,7 @@ function addPostsCountToModComponent() {
     
     try {
       // Fetch the mod page to get the posts count
+      postsFetched++;
       const postsCount = await fetchPostsCount(modUrl);
       if ((typeof global !== 'undefined' && global.isTestEnvironment)) {
         console.log(`MOD_TWEAKS_DEBUG: Received postsCount: ${postsCount} for modUrl: ${modUrl}`);
@@ -160,7 +169,7 @@ function addPostsCountToModComponent() {
     } catch (error) {
       console.error('Error adding posts count:', error);
     }
-  });
+  }
 }
 
 /**

--- a/tests/modComponentTweaks.test.js
+++ b/tests/modComponentTweaks.test.js
@@ -1,4 +1,4 @@
-// modComponentTweaks.test.js
+// posts.test.js
 const { waitFor } = require('@testing-library/dom');
 
 // HTML structure for a mod tile
@@ -12,7 +12,7 @@ const MOD_TILE_HTML = `
   </div>
 `;
 
-describe('Mod Component Tweaks', () => {
+describe('Posts feature', () => {
   beforeEach(() => {
     // Set up the DOM
     document.body.innerHTML = MOD_TILE_HTML;
@@ -46,7 +46,7 @@ describe('Mod Component Tweaks', () => {
   test('should add post counts when displayPostCount is true on initial load', async () => {
     // Load and execute the script. initModComponentTweaks() is called at its end.
     // jest.resetModules() in afterEach ensures this is a fresh load.
-    require('../src/modComponentTweaks.js');
+    require('../src/posts.js');
 
     const modTile = document.querySelector('[data-e2eid="mod-tile"]');
     const modTileFooter = modTile.querySelector('.bg-surface-high.mt-auto');
@@ -84,7 +84,7 @@ describe('Mod Component Tweaks', () => {
       return Promise.resolve(result);
     });
 
-    require('../src/modComponentTweaks.js');
+    require('../src/posts.js');
 
     const modTile = document.querySelector('[data-e2eid="mod-tile"]');
 
@@ -95,6 +95,18 @@ describe('Mod Component Tweaks', () => {
 
     expect(modTile.hasAttribute('data-posts-added')).toBe(false);
     expect(chrome.storage.sync.get).toHaveBeenCalled();
+  });
+
+  test('limits fetching posts to first 20 mod tiles', async () => {
+    const tiles = new Array(25).fill(MOD_TILE_HTML).join('');
+    document.body.innerHTML = tiles;
+
+    require('../src/posts.js');
+
+    await waitFor(() => {
+      const posts = document.querySelectorAll('.mod-tile-posts-count-element');
+      expect(posts.length).toBe(20);
+    });
   });
 
   // TODO: Add test for toggling displayPostCount from true to false


### PR DESCRIPTION
## Summary
- rename `modComponentTweaks.js` -> `posts.js`
- update manifest to use new file
- limit post fetching to 20 items per page load
- adjust and extend Jest tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fb46fd3888325ab023fea57caeb4f