### PR TITLE
Limit concurrent post count fetches

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -3,6 +3,33 @@ const POSTS_CACHE_EXPIRY_MS = 24 * 60 * 60 * 1000; // 1 day
 // Simple in-memory cache to avoid hitting chrome.storage write limits
 const postsCache = {};
 
+// === Request queue to limit concurrent fetches ==============================
+const MAX_ACTIVE_POST_REQUESTS = 3;
+let activePostRequests = 0;
+const postRequestQueue = [];
+
+function processPostQueue() {
+  if (activePostRequests >= MAX_ACTIVE_POST_REQUESTS) return;
+  const next = postRequestQueue.shift();
+  if (!next) return;
+
+  activePostRequests++;
+  fetchPostCount(next.url)
+    .then(data => next.resolve(data))
+    .catch(err => next.reject(err))
+    .finally(() => {
+      activePostRequests--;
+      processPostQueue();
+    });
+}
+
+function queueFetchPostCount(url) {
+  return new Promise((resolve, reject) => {
+    postRequestQueue.push({ url, resolve, reject });
+    processPostQueue();
+  });
+}
+
 chrome.runtime.onMessage.addListener((msg, sender, respond) => {
   if (msg.type === 'fetchPostCount' && msg.url) {
     handlePostCount(msg.url)
@@ -18,7 +45,7 @@ async function handlePostCount(url) {
     return cached.data;
   }
 
-  const data = await fetchPostCount(url);
+  const data = await queueFetchPostCount(url);
   postsCache[url] = { data, expiry: Date.now() + POSTS_CACHE_EXPIRY_MS };
   return data;
 }


### PR DESCRIPTION
## Summary
- add a queue in `background.js` limiting active requests to 3
- use the queue for `fetchPostCount`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fb5f1d0b48325b55c1fbe318ad238