### PR TITLE
Add persistent post count caching

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -3,6 +3,8 @@ const POSTS_CACHE_EXPIRY_MS = 24 * 60 * 60 * 1000; // 1 day
 // Simple in-memory cache to avoid hitting chrome.storage write limits
 const postsCache = {};
 
+purgeExpiredStorage();
+
 chrome.runtime.onMessage.addListener((msg, sender, respond) => {
   if (msg.type === 'fetchPostCount' && msg.url) {
     handlePostCount(msg.url)
@@ -18,8 +20,18 @@ async function handlePostCount(url) {
     return cached.data;
   }
 
+  const storageValue = await readPostCountFromStorage(url);
+  if (storageValue !== null) {
+    postsCache[url] = {
+      data: storageValue,
+      expiry: Date.now() + POSTS_CACHE_EXPIRY_MS,
+    };
+    return storageValue;
+  }
+
   const data = await fetchPostCount(url);
   postsCache[url] = { data, expiry: Date.now() + POSTS_CACHE_EXPIRY_MS };
+  writePostCountToStorage(url, data, Date.now() + POSTS_CACHE_EXPIRY_MS);
   return data;
 }
 
@@ -29,4 +41,47 @@ async function fetchPostCount(url) {
   const text = await resp.text();
   const match = text.match(/data-nexus-posts-count="(\d+)"/);
   return match ? match[1] : '0';
+}
+
+function readPostCountFromStorage(url) {
+  const key = `postCount_${url}`;
+  return new Promise(resolve => {
+    try {
+      chrome.storage.local.get(key, items => {
+        const entry = items[key];
+        if (entry && entry.expiry && entry.expiry > Date.now()) {
+          resolve(entry.value);
+        } else {
+          if (entry) chrome.storage.local.remove(key);
+          resolve(null);
+        }
+      });
+    } catch (err) {
+      console.error('readPostCountFromStorage error:', err);
+      resolve(null);
+    }
+  });
+}
+
+function writePostCountToStorage(url, value, expiry) {
+  const key = `postCount_${url}`;
+  try {
+    chrome.storage.local.set({ [key]: { value, expiry } });
+  } catch (err) {
+    console.error('writePostCountToStorage error:', err);
+  }
+}
+
+function purgeExpiredStorage() {
+  try {
+    chrome.storage.local.get(null, items => {
+      const now = Date.now();
+      const toRemove = Object.entries(items)
+        .filter(([_, val]) => val && val.expiry && now >= val.expiry)
+        .map(([key]) => key);
+      if (toRemove.length) chrome.storage.local.remove(toRemove);
+    });
+  } catch (err) {
+    console.error('purgeExpiredStorage error:', err);
+  }
 }


### PR DESCRIPTION
## Summary
- cache mod post counts in `chrome.storage.local` with expiry timestamps
- purge expired cached entries on startup
- read from storage cache when handling `fetchPostCount` requests
- write newly fetched counts to storage

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683fb5f6cc9083259a6ca5854db1e1b7