### PR TITLE
Fix post count retrieval

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -45,7 +45,13 @@ async function handlePostCount(url) {
   if (cached && Date.now() < cached.expiry) {
     return cached.data;
   }
+  const stored = await readPostCountFromStorage(url);
+  if (stored) {
+    postsCache[url] = { data: stored, expiry: Date.now() + POSTS_CACHE_EXPIRY_MS };
+    return stored;
+  }
 
+  const data = await queueFetchPostCount(url);
   postsCache[url] = { data, expiry: Date.now() + POSTS_CACHE_EXPIRY_MS };
   writePostCountToStorage(url, data, Date.now() + POSTS_CACHE_EXPIRY_MS);
   return data;


### PR DESCRIPTION
## Summary
- handle background post count fetching correctly
- retrieve from storage or the queue instead of undefined variable

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683fb9e5d624832585a5cf18cc95245c